### PR TITLE
attempt to subtract with overflow

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -58,7 +58,7 @@ impl<T: PossibleValues, const D: usize> Grid<T, D> {
                     .0
                     .iter()
                     .enumerate()
-                    .filter(|(i, x)| location[*i] - **x != 0)
+                    .filter(|(i, x)| location[*i].checked_sub(**x).is_some())
                     .count()
                     == 1
             })
@@ -76,7 +76,9 @@ impl<T: PossibleValues, const D: usize> Grid<T, D> {
             .unwrap();
         let mut loc = start_location;
         loop {
-            r.push((loc, self.get_item(loc)));
+            if loc != location {
+                r.push((loc, self.get_item(loc)));
+            }
             for n in 0..D {
                 loc[n] += 1;
                 if loc[n] > location[n] + distance || loc[n] == self.size[n] {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -58,7 +58,7 @@ impl<T: PossibleValues, const D: usize> Grid<T, D> {
                     .0
                     .iter()
                     .enumerate()
-                    .filter(|(i, x)| location[*i].checked_sub(**x).is_some())
+                    .filter(|(i, x)| location[*i].overflowing_sub(**x).0 != 0)
                     .count()
                     == 1
             })


### PR DESCRIPTION
Running the example panics at line 61 because it somehow gets a negative number with the usizes. This just does a checked_sub and sees if it is `some`.

```
thread 'main' panicked at 'attempt to subtract with overflow',
```

I also added a check to see if the location is not equal to the current center location of neighbors before adding it to the result.