### PR TITLE
Change ascii for pretty blocks

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -11,12 +11,12 @@ enum Tile {
     Grass,
 }
 
-impl Tile {
-    fn to_char(&self) -> char {
-        match self {
-            Tile::Dirt => '🟫',
-            Tile::Grass => '🟩',
-            Tile::Water => '🟦',
+impl From<Tile> for String {
+    fn from(val: Tile) -> Self {
+        match val {
+            Tile::Dirt => "\x1b[1;30m█\x1b[0m".to_string(),
+            Tile::Grass => "\x1b[1;32m█\x1b[0m".to_string(),
+            Tile::Water => "\x1b[1;34m█\x1b[0m".to_string(),
         }
     }
 }
@@ -69,12 +69,14 @@ fn main() {
                     s += "\n";
                     for x in 0..grid.size()[1] {
                         if let Some(x) = grid.get_item([x, y]).determined_value {
-                            s += x.to_char().to_string().as_str();
+                            s += &String::from(x);
                         } else {
-                            s += "  ";
+                            s += " ";
                         }
                     }
                 }
+                // Clear the screen
+                print!("\x1b[2J\x1b[1;1H");
                 println!("{}", s);
                 thread::sleep(Duration::from_millis(10));
             },

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -14,9 +14,9 @@ enum Tile {
 impl From<Tile> for String {
     fn from(val: Tile) -> Self {
         match val {
-            Tile::Dirt => "\x1b[1;30m█\x1b[0m".to_string(),
-            Tile::Grass => "\x1b[1;32m█\x1b[0m".to_string(),
-            Tile::Water => "\x1b[1;34m█\x1b[0m".to_string(),
+            Tile::Dirt => "\x1b[1;30m██\x1b[0m".to_string(),
+            Tile::Grass => "\x1b[1;32m██\x1b[0m".to_string(),
+            Tile::Water => "\x1b[1;34m██\x1b[0m".to_string(),
         }
     }
 }
@@ -71,12 +71,13 @@ fn main() {
                         if let Some(x) = grid.get_item([x, y]).determined_value {
                             s += &String::from(x);
                         } else {
-                            s += " ";
+                            s += "  ";
                         }
                     }
                 }
                 // Clear the screen
                 print!("\x1b[2J\x1b[1;1H");
+
                 println!("{}", s);
                 thread::sleep(Duration::from_millis(10));
             },

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -16,9 +16,9 @@ impl From<Tile> for String {
         // See ANSI escape codes for 8-bit colors:
         // https://en.wikipedia.org/wiki/ANSI_escape_sequence#8-bit
         match val {
-            Tile::Water => "\x1b[1;34m██".to_string(),
-            Tile::Dirt => "\x1b[1;33m██".to_string(),
-            Tile::Grass => "\x1b[1;32m██".to_string(),
+            Tile::Water => "\x1b[38;5;21m██\x1b[0m".to_string(),
+            Tile::Dirt => "\x1b[38;5;94m██\x1b[0m".to_string(),
+            Tile::Grass => "\x1b[38;5;28m██\x1b[0m".to_string(),
         }
     }
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -32,6 +32,9 @@ fn main() {
     // Make a new 30-by-30 grid.
     let mut grid: Grid<Tile, 2> = Grid::new([30, 30]).unwrap();
     loop {
+        // Clear the screen
+        print!("\x1b[2J");
+
         let r = grid.wfc(
             |g, loc, me, probability| {
                 // We use !any(|x| ...) to get none(|x| ...) functionality
@@ -75,8 +78,6 @@ fn main() {
                         }
                     }
                 }
-                // Clear the screen
-                print!("\x1b[2J\x1b[1;1H");
 
                 println!("{}", s);
                 thread::sleep(Duration::from_millis(10));

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -17,7 +17,7 @@ impl From<Tile> for String {
         // https://en.wikipedia.org/wiki/ANSI_escape_sequence#8-bit
         match val {
             Tile::Water => "\x1b[1;34m██".to_string(),
-            Tile::Dirt => "\x1b[38;2;200;150;100m██".to_string(),
+            Tile::Dirt => "\x1b[1;33m██".to_string(),
             Tile::Grass => "\x1b[1;32m██".to_string(),
         }
     }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -13,10 +13,12 @@ enum Tile {
 
 impl From<Tile> for String {
     fn from(val: Tile) -> Self {
+        // See ANSI escape codes for 8-bit colors:
+        // https://en.wikipedia.org/wiki/ANSI_escape_sequence#8-bit
         match val {
-            Tile::Dirt => "\x1b[1;30m██\x1b[0m".to_string(),
-            Tile::Grass => "\x1b[1;32m██\x1b[0m".to_string(),
-            Tile::Water => "\x1b[1;34m██\x1b[0m".to_string(),
+            Tile::Water => "\x1b[1;34m██".to_string(),
+            Tile::Dirt => "\x1b[38;2;200;150;100m██".to_string(),
+            Tile::Grass => "\x1b[1;32m██".to_string(),
         }
     }
 }
@@ -32,9 +34,6 @@ fn main() {
     // Make a new 30-by-30 grid.
     let mut grid: Grid<Tile, 2> = Grid::new([30, 30]).unwrap();
     loop {
-        // Clear the screen
-        print!("\x1b[2J");
-
         let r = grid.wfc(
             |g, loc, me, probability| {
                 // We use !any(|x| ...) to get none(|x| ...) functionality
@@ -67,6 +66,9 @@ fn main() {
             &mut rng,
             0.05,
             |grid| {
+                // Clear the screen
+                println!("\x1b[H\x1b[2J\x1b[3J");
+
                 let mut s = String::new();
                 for y in 0..grid.size()[0] {
                     s += "\n";

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -36,7 +36,7 @@ fn main() {
             |g, loc, me, probability| {
                 // We use !any(|x| ...) to get none(|x| ...) functionality
                 match *me {
-                    // Disallow stone next to grass
+                    // Disallow water next to grass
                     Tile::Water => (
                         !g.unidirectional_neighbors(loc).iter().any(|x| {
                             x.1.determined_value
@@ -48,7 +48,7 @@ fn main() {
                     ),
                     // Dirt is always allowed
                     Tile::Dirt => (true, probability),
-                    // Disallow grass next to stone
+                    // Disallow grass next to water
                     Tile::Grass => (
                         !g.unidirectional_neighbors(loc).iter().any(|x| {
                             x.1.determined_value

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,45 +5,55 @@ use microwfc::*;
 use rand::thread_rng;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-enum Test {
-    Stone,
+enum Tile {
+    Water,
     Dirt,
     Grass,
 }
 
-impl PossibleValues for Test {
+impl Tile {
+    fn to_char(&self) -> char {
+        match self {
+            Tile::Dirt => '🟫',
+            Tile::Grass => '🟩',
+            Tile::Water => '🟦',
+        }
+    }
+}
+
+impl PossibleValues for Tile {
     fn get_possible_values() -> Vec<(Self, f32)> {
-        vec![(Self::Grass, 4f32), (Self::Dirt, 1f32), (Self::Stone, 3f32)]
+        vec![(Self::Grass, 4f32), (Self::Dirt, 1f32), (Self::Water, 3f32)]
     }
 }
 
 fn main() {
     let mut rng = thread_rng();
     // Make a new 30-by-30 grid.
-    let mut grid: Grid<Test, 2> = Grid::new([30, 30]).unwrap();
+    let mut grid: Grid<Tile, 2> = Grid::new([30, 30]).unwrap();
     loop {
         let r = grid.wfc(
             |g, loc, me, probability| {
                 // We use !any(|x| ...) to get none(|x| ...) functionality
                 match *me {
                     // Disallow stone next to grass
-                    Test::Stone => (
+                    Tile::Water => (
                         !g.unidirectional_neighbors(loc).iter().any(|x| {
                             x.1.determined_value
                                 .as_ref()
-                                .map(|x| *x == Test::Grass)
+                                .map(|x| *x == Tile::Grass)
                                 .unwrap_or(false) // Allow unsolved pixels
                         }),
                         probability,
                     ),
                     // Dirt is always allowed
-                    Test::Dirt => (true, probability),
+                    Tile::Dirt => (true, probability),
                     // Disallow grass next to stone
-                    Test::Grass => (
+                    Tile::Grass => (
                         !g.unidirectional_neighbors(loc).iter().any(|x| {
                             x.1.determined_value
                                 .as_ref()
-                                .map(|x| *x == Test::Stone)
+                                .map(|x| *x == Tile::Water)
                                 .unwrap_or(false)
                         }),
                         probability,
@@ -59,11 +69,7 @@ fn main() {
                     s += "\n";
                     for x in 0..grid.size()[1] {
                         if let Some(x) = grid.get_item([x, y]).determined_value {
-                            s += match x {
-                                Test::Stone => "##",
-                                Test::Dirt => "YY",
-                                Test::Grass => "//",
-                            };
+                            s += x.to_char().to_string().as_str();
                         } else {
                             s += "  ";
                         }


### PR DESCRIPTION
The current ascii example looks a little bland considering how cool the algorithm is. This just changes the test enum to a tile enum that represents the tiles with colorful block emojis
<img width="666" alt="Screen Shot 2023-01-26 at 9 18 25 PM" src="https://user-images.githubusercontent.com/29642168/215015236-c81416e4-7f6b-4c7a-915a-b840e0caeb85.png">
